### PR TITLE
fix: Blitz upgrade

### DIFF
--- a/app/core/updateSession.ts
+++ b/app/core/updateSession.ts
@@ -1,12 +1,12 @@
 import { setPublicDataForUser } from "@blitzjs/auth";
-import { AuthenticatedMiddlewareCtx } from "blitz";
+import { AuthenticatedCtx } from "blitz";
 import type { User, Membership } from "db";
 
 export async function updateSession(
   membership: Membership & {
     user: User | null;
   },
-  ctx: AuthenticatedMiddlewareCtx
+  ctx: AuthenticatedCtx
 ) {
   const { user } = membership;
 

--- a/app/lib/utils_server.server.test.ts
+++ b/app/lib/utils_server.server.test.ts
@@ -1,6 +1,6 @@
 import { expect, describe, it, test } from "vitest";
 
-import { AuthenticatedMiddlewareCtx } from "blitz";
+import { AuthenticatedCtx } from "blitz";
 import { getRandomMockCtxAndUser } from "test/shared";
 import { enforceWfcQuota, parseSymbolization } from "./utils_server";
 import { env } from "app/lib/env_client";
@@ -15,9 +15,7 @@ test("parseSymbolization", () => {
 describe("enforceWfcQuota", () => {
   it("base case - exceeding limit", async () => {
     const { ctx } = await getRandomMockCtxAndUser();
-    await expect(
-      enforceWfcQuota(ctx as AuthenticatedMiddlewareCtx)
-    ).resolves.toBeFalsy();
+    await expect(enforceWfcQuota(ctx as AuthenticatedCtx)).resolves.toBeFalsy();
 
     for (let i = 0; i < 50; i++) {
       await expect(
@@ -29,9 +27,9 @@ describe("enforceWfcQuota", () => {
       createWrappedFeatureCollection({ name: "Foo" }, ctx)
     ).rejects.toThrowError(/limit/);
 
-    await expect(
-      enforceWfcQuota(ctx as AuthenticatedMiddlewareCtx)
-    ).rejects.toThrowError(/limit/);
+    await expect(enforceWfcQuota(ctx as AuthenticatedCtx)).rejects.toThrowError(
+      /limit/
+    );
 
     await db.organization.update({
       where: {
@@ -42,8 +40,6 @@ describe("enforceWfcQuota", () => {
       },
     });
 
-    await expect(
-      enforceWfcQuota(ctx as AuthenticatedMiddlewareCtx)
-    ).resolves.toBeFalsy();
+    await expect(enforceWfcQuota(ctx as AuthenticatedCtx)).resolves.toBeFalsy();
   });
 });

--- a/app/lib/utils_server.ts
+++ b/app/lib/utils_server.ts
@@ -1,4 +1,4 @@
-import { AuthenticatedMiddlewareCtx } from "blitz";
+import { AuthenticatedCtx } from "blitz";
 import LAYERS from "app/lib/default_layers";
 import db, { MembershipStatus, Prisma } from "db";
 import { generateKeyBetween } from "fractional-indexing";
@@ -15,10 +15,7 @@ import { QuotaError } from "./errors";
 import { UOrganization } from "./uorganization";
 import { formatCount, safeParseMaybe } from "./utils";
 
-export function getWrappedFeatureCollection(
-  id: string,
-  ctx: AuthenticatedMiddlewareCtx
-) {
+export function getWrappedFeatureCollection(id: string, ctx: AuthenticatedCtx) {
   return db.wrappedFeatureCollection.findFirstOrThrow({
     where: {
       id,
@@ -29,7 +26,7 @@ export function getWrappedFeatureCollection(
   });
 }
 
-export async function enforceWfcQuota(ctx: AuthenticatedMiddlewareCtx) {
+export async function enforceWfcQuota(ctx: AuthenticatedCtx) {
   const organization = await db.organization.findFirstOrThrow({
     where: {
       id: ctx.session.orgId!,

--- a/app/users/queries/getCurrentUser.test.ts
+++ b/app/users/queries/getCurrentUser.test.ts
@@ -1,6 +1,6 @@
 import { expect, describe, it } from "vitest";
 
-import { AuthenticatedMiddlewareCtx } from "blitz";
+import { AuthenticatedCtx } from "blitz";
 import { getRandomMockCtxAndUser } from "test/shared";
 import { getCurrentUserInternal } from "./getCurrentUser";
 
@@ -8,7 +8,7 @@ describe("getCurrentUser", () => {
   it("base case", async () => {
     const { ctx } = await getRandomMockCtxAndUser();
     await expect(
-      getCurrentUserInternal(ctx as AuthenticatedMiddlewareCtx)
+      getCurrentUserInternal(ctx as AuthenticatedCtx)
     ).resolves.toBeTruthy();
   });
 });

--- a/app/users/queries/getCurrentUser.ts
+++ b/app/users/queries/getCurrentUser.ts
@@ -1,8 +1,8 @@
 import { resolver } from "@blitzjs/rpc";
-import { AuthenticatedMiddlewareCtx } from "blitz";
+import { AuthenticatedCtx } from "blitz";
 import db from "db";
 
-export async function getCurrentUserInternal(ctx: AuthenticatedMiddlewareCtx) {
+export async function getCurrentUserInternal(ctx: AuthenticatedCtx) {
   const user = await db.user.findFirstOrThrow({
     where: { id: ctx.session.userId },
     select: {

--- a/app/users/queries/getMaybeCurrentUser.ts
+++ b/app/users/queries/getMaybeCurrentUser.ts
@@ -1,9 +1,9 @@
-import { Ctx, AuthenticatedMiddlewareCtx } from "blitz";
+import { Ctx, AuthenticatedCtx } from "blitz";
 import { getCurrentUserInternal } from "app/users/queries/getCurrentUser";
 
 export default async function getMaybeCurrentUser(_ = null, ctx: Ctx) {
   try {
-    return await getCurrentUserInternal(ctx as AuthenticatedMiddlewareCtx);
+    return await getCurrentUserInternal(ctx as AuthenticatedCtx);
   } catch (e) {
     return null;
   }

--- a/package.json
+++ b/package.json
@@ -181,7 +181,6 @@
     "topojson-client": "^3.1.0",
     "topojson-server": "^3.0.1",
     "ts-pattern": "^4.0.5",
-    "tslog": "^4.8.2",
     "type-fest": "^4.0.0",
     "uuid": "^9.0.0",
     "xlsx": "^0.18.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12702,11 +12702,6 @@ tslog@4.9.0:
   resolved "https://registry.yarnpkg.com/tslog/-/tslog-4.9.0.tgz#94988ed35ec0e7ed6fd921124cdc5ead0acf2454"
   integrity sha512-YEb55YxukbKO0bSAAsd9eSnw6RA0e3jt3cniZ00wj9offySAbp20lBrjOh1OTn11L51r58V4kFy8h7dMPnbpmg==
 
-tslog@^4.8.2:
-  version "4.8.2"
-  resolved "https://registry.yarnpkg.com/tslog/-/tslog-4.8.2.tgz#dbb0c96249e387e8a711ae6e077330ba1ef102c9"
-  integrity sha512-eAKIRjxfSKYLs06r1wT7oou6Uv9VN6NW9g0JPidBlqQwPBBl5+84dm7r8zSOPVq1kyfEw1P6B3/FLSpZCorAgA==
-
 tsscmp@1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/tsscmp/-/tsscmp-1.0.6.tgz#85b99583ac3589ec4bfef825b5000aa911d605eb"


### PR DESCRIPTION
Fixed 2 issues after blitz 2.0.2 upgrade (see https://github.com/placemark/placemark/pull/19)

- `AuthenticatedMiddlewareCtx` was renamed to `AuthenticatedCtx`
- `tslog` package mismatch - just use the one pulled in by blitz.