### PR TITLE
Add "Getting started" for Play

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .next
 .DS_Store
 .tsbuildinfo
+packages/play/out

--- a/packages/play/README.md
+++ b/packages/play/README.md
@@ -19,3 +19,41 @@ and all of that. It's a real experiment - expect breakage, and hopefully contrib
 pull requests. I'm happy to try and make Placemark useful to folks, and don't
 feel bad or bitter about the fate of the company, but realistically if the
 open source project is to succeed, it'll need contributors as well as users.
+
+## Getting started
+
+There are more sophisticated approaches using Docker or Render (see files), but
+the following simple approach works locally on macOS:
+
+1. Clone the repository, change to this directory, and install dependencies:
+
+```
+git clone 
+cd placemark/packages/play
+pnpm install
+```
+
+2. Obtain a [Mapbox public access token](https://account.mapbox.com/)
+([docs](https://docs.mapbox.com/help/getting-started/access-tokens/)) and
+[Geocode Earth token](https://app.geocode.earth/keys)
+([docs](https://geocode.earth/docs/intro/authentication/)).
+
+4. Build the package with the tokens from the previous step:
+
+```sh
+NEXT_PUBLIC_MAPBOX_TOKEN="<your Mapbox public access token>" \
+NEXT_PUBLIC_GEOCODE_EARTH_TOKEN="<your Geocode Earth token>" \
+pnpm build
+
+```
+
+4. Start the server:
+
+```sh
+npx serve@latest out
+```
+
+5. Visit [http://localhost:3000](http://localhost:3000)
+
+If you're planning to run this often or publicly, take care to secure your
+tokens better, and consider copying and revising the `.env.sample` file.

--- a/packages/play/README.md
+++ b/packages/play/README.md
@@ -56,4 +56,5 @@ npx serve@latest out
 5. Visit [http://localhost:3000](http://localhost:3000)
 
 If you're planning to run this often or publicly, take care to secure your
-tokens better, and consider copying and revising the `.env.sample` file.
+tokens better by adding [URL restrictions to the Mapbox token](https://docs.mapbox.com/help/getting-started/access-tokens/#url-restrictions) and setting allowed Referrer Hostnames to the Geocode Earth one,
+and consider copying and revising the `.env.sample` file.


### PR DESCRIPTION
It took me a few minutes to get Play set up, and I thought someone else might benefit from some documentation. Open questions:

1. I made screenshots of the token process (with fake data). Do you want those in the repo? Should I outline the token areas?

<details>
<summary>Screenshots</summary>

![mapbox-token](https://github.com/placemark/placemark/assets/875982/7ca20896-0e91-405b-8af9-5a18770a544e)
![geocode-earth-token](https://github.com/placemark/placemark/assets/875982/2ce7abcd-62eb-4572-a046-8aee734fb1a4)



</details>

2. In step 4, I'm following the advice printed in terminal because running `pnpm start` fails, and I haven't looked into fixing that yet. Is that acceptable?

<details><summary>Error message</summary>

```
> @placemarkio/play@0.1.0 start /Volumes/Blue 2TB 2/placemark/packages/play
> next start

   ▲ Next.js 14.1.0
   - Local:        http://localhost:3000

Error: "next start" does not work with "output: export" configuration. Use "npx serve@latest out" instead.
    at /Volumes/Blue 2TB 2/placemark/node_modules/.pnpm/next@14.1.0_@babel+core@7.23.9_react-dom@18.2.0_react@18.2.0/node_modules/next/dist/server/next.js:208:31
    at async NextServer.prepare (/Volumes/Blue 2TB 2/placemark/node_modules/.pnpm/next@14.1.0_@babel+core@7.23.9_react-dom@18.2.0_react@18.2.0/node_modules/next/dist/server/next.js:152:24)
    at async initializeImpl (/Volumes/Blue 2TB 2/placemark/node_modules/.pnpm/next@14.1.0_@babel+core@7.23.9_react-dom@18.2.0_react@18.2.0/node_modules/next/dist/server/lib/render-server.js:91:5)
    at async initialize (/Volumes/Blue 2TB 2/placemark/node_modules/.pnpm/next@14.1.0_@babel+core@7.23.9_react-dom@18.2.0_react@18.2.0/node_modules/next/dist/server/lib/router-server.js:109:22)
    at async Server.<anonymous> (/Volumes/Blue 2TB 2/placemark/node_modules/.pnpm/next@14.1.0_@babel+core@7.23.9_react-dom@18.2.0_react@18.2.0/node_modules/next/dist/server/lib/start-server.js:246:36)
 ELIFECYCLE  Command failed with exit code 1.
```

</details>

3. My `packages/play/out` directory doesn't seem to be excluded by the .gitignore, but I generally exclude such generated directories. Should I add it to .gitignore?
