### PR TITLE
Change source buffer to 0

### DIFF
--- a/app/lib/__snapshots__/load_and_augment_style.test.ts.snap
+++ b/app/lib/__snapshots__/load_and_augment_style.test.ts.snap
@@ -213,7 +213,7 @@ exports[`loadAndAugmentStyle 1`] = `
   "name": "XYZ Layer",
   "sources": {
     "ephemeral": {
-      "buffer": 512,
+      "buffer": 0,
       "data": {
         "features": [],
         "type": "FeatureCollection",
@@ -222,7 +222,7 @@ exports[`loadAndAugmentStyle 1`] = `
       "type": "geojson",
     },
     "features": {
-      "buffer": 512,
+      "buffer": 0,
       "data": {
         "features": [],
         "type": "FeatureCollection",
@@ -1502,7 +1502,7 @@ exports[`makeLayers > ramp 2`] = `
       color = ramp[i + 1];
     }
   }
-  
+
   return {
     color: color || \\"#312E81\\",
     weight: 2,

--- a/app/lib/load_and_augment_style.ts
+++ b/app/lib/load_and_augment_style.ts
@@ -46,7 +46,7 @@ export const FEATURES_FILL_LAYER_NAME = "features-fill";
 const emptyGeoJSONSource = {
   type: "geojson",
   data: emptyFeatureCollection,
-  buffer: 512,
+  buffer: 0,
   tolerance: 0,
 } as const;
 


### PR DESCRIPTION
As mentioned in [this issue](https://github.com/placemark/placemark/issues/90), Placemark suffers to load big GeoJSON files (~50k lines). Changing the buffer option from 512 to 0 as [suggested by mapbox](https://docs.mapbox.com/help/troubleshooting/working-with-large-geojson-data/#adjusting-the-buffer) improves the performance and memory consumption significantly. 