### PR TITLE
Use store from outside react

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,7 +4,7 @@ import { PersistenceContext } from "app/lib/persistence/context";
 import { MemPersistence } from "app/lib/persistence/memory";
 import { Provider, createStore } from "jotai";
 import { UIDMap } from "app/lib/id_mapper";
-import { layerConfigAtom } from "state/jotai";
+import { Store, layerConfigAtom } from "state/jotai";
 import { newFeatureId } from "app/lib/id";
 import LAYERS from "app/lib/default_layers";
 import dynamic from "next/dynamic";
@@ -16,11 +16,13 @@ const PlacemarkPlay = dynamic(
   }
 );
 
-function ScratchpadInner() {
+function ScratchpadInner({ store }: { store: Store }) {
   const idMap = useRef(UIDMap.empty());
 
   return (
-    <PersistenceContext.Provider value={new MemPersistence(idMap.current)}>
+    <PersistenceContext.Provider
+      value={new MemPersistence(idMap.current, store)}
+    >
       <>
         <Head>
           <title>Placemark Play</title>
@@ -57,7 +59,7 @@ const Play = () => {
 
   return (
     <Provider key="play" store={store}>
-      <ScratchpadInner />
+      <ScratchpadInner store={store} />
     </Provider>
   );
 };

--- a/state/jotai.ts
+++ b/state/jotai.ts
@@ -1,4 +1,4 @@
-import { atom } from "jotai";
+import { atom, createStore } from "jotai";
 import { atomWithStorage, selectAtom } from "jotai/utils";
 import type { FileSystemHandle } from "browser-fs-access";
 import type { SetOptional } from "type-fest";
@@ -22,6 +22,8 @@ import { createMachine } from "xstate";
 import { QItemAddable } from "app/lib/geocode";
 import { PersistenceMetadataMemory } from "app/lib/persistence/ipersistence";
 import { ScaleUnit } from "app/lib/constants";
+
+export type Store = ReturnType<typeof createStore>;
 
 // TODO: make this specific
 type MapboxLayer = any;


### PR DESCRIPTION
@sapagat and I ran into a weird edge case in our fork of Placemark, and we found that refactoring this section of code as per Jotai's docs solved our issue:
https://jotai.org/docs/guides/using-store-outside-react

The existing code may be fine as it is, but we thought it was worth contributing back upstream and also getting rid of the ESLint warning about using useCallback and useAtomCallback from a class.