### PR TITLE
remove @circle prop on simplify

### DIFF
--- a/app/lib/map_operations/simplify.ts
+++ b/app/lib/map_operations/simplify.ts
@@ -8,6 +8,7 @@ import type {
   Polygon,
   Position,
 } from "types";
+import { getCircleProp } from "../circle";
 
 export type SimplifySupportedGeometry =
   | LineString
@@ -162,6 +163,16 @@ export function simplify(
   feature: IFeature<SimplifySupportedGeometry>,
   options: SimplifyOptions,
 ) {
+  // if a circle is simplified, remove its @circle property
+  // it will be treated as a normal polygon going forward
+  // this prevents restoring the unsimplified circle geometry
+  // if it is moved (shift + drag)
+
+  const circleProp = getCircleProp(feature);
+
+  if (circleProp && feature.properties) {
+    delete feature.properties['@circle'];
+  }
   return {
     ...feature,
     geometry: simplifyGeom(feature.geometry, options),


### PR DESCRIPTION
Fixes a bug where a simplified circle geometry would be restored to its unsimplified state when being moved with (shift + drag)

Circles created with the circle drawing tool retain a `@circle` prop with their type and center point. The move function calls `makeCircleNative()` if it detects this `@circle` prop, which restores the circle to its un-simplified number of vertices. This is important for making sure the circle does what it is supposed to do depending on its type and latitude, but overwrites the geometry so becomes a non-sequitur if the geometry has been modified. Circles do not allow moving of individual vertices, so simplifying seems like 

This change deletes the `@circle` prop when simplifying a geometry, effectively treating the circle as a regular polygon after simplification.

It may make sense to warn the user in the simplify modal that this change is happening. Circles are special, and if the user doesn't already know that it could add confusion.

