### PR TITLE
Fix documentation link

### DIFF
--- a/.changeset/loose-ants-film.md
+++ b/.changeset/loose-ants-film.md
@@ -1,0 +1,5 @@
+---
+"@placemarkio/play": patch
+---
+
+Fix link to documentation site

--- a/app/components/menu_bar.tsx
+++ b/app/components/menu_bar.tsx
@@ -60,7 +60,7 @@ function HelpDot() {
         </StyledItem>
         <StyledItem
           onSelect={() => {
-            window.open("https://www.placemark.io/documentation-index");
+            window.open("https://placemark.github.io/docs/");
           }}
         >
           <ReaderIcon /> Documentation


### PR DESCRIPTION
This also links to the new-old documentation, which I recreated as a website instead of just a repo, at https://placemark.github.io/docs/

- Fixes #246